### PR TITLE
Addressess issues #3, #4, #5 and #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,22 @@ Ensure AAAA record
     pdns_prot: https
 ```
 
+Do not verify SSL certificate
+Ensure AAAA record
+```yaml
+- powerdns_record:
+    name: host01.zone01.internal.example.com.
+    zone: zone01.internal.example.com
+    type: AAAA
+    content: 2001:cdba:0000:0000:0000:0000:3257:9652
+    ttl: 1440
+    pdns_host: powerdns.example.com
+    pdns_port: 8443
+    pdns_api_key: topsecret
+    pdns_prot: https
+    strict_ssl_checking: false
+```
+
 Ensure CNAME record
 ```yaml
 - powerdns_record:

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Ensure zone is present
 
 ```yaml
 - powerdns_zone:
-    name: zone01.internal.example.com
+    name: zone01.internal.example.com.
     nameservers:
-    - ns-01.example.com
-    - ns-02.example.com
+    - ns-01.example.com.
+    - ns-02.example.com.
     kind: master
     state: present
     pdns_host: powerdns.example.com
@@ -38,7 +38,7 @@ Ensure zone is absent
 Ensure A record
 ```yaml
 - powerdns_record:
-    name: host01
+    name: host01.zone01.internal.example.com.
     zone: zone01.internal.example.com
     type: A
     content: 192.168.1.234
@@ -51,7 +51,7 @@ Ensure A record
 Ensure AAAA record
 ```yaml
 - powerdns_record:
-    name: host01
+    name: host01.zone01.internal.example.com.
     zone: zone01.internal.example.com
     type: AAAA
     content: 2001:cdba:0000:0000:0000:0000:3257:9652
@@ -64,7 +64,7 @@ Ensure AAAA record
 Ensure CNAME record
 ```yaml
 - powerdns_record:
-    name: database
+    name: database.zone01.internal.example.com.
     zone: zone01.internal.example.com
     type: CNAME
     content: host01.zone01.internal.example.com
@@ -72,3 +72,5 @@ Ensure CNAME record
     pdns_port: 8081
     pdns_api_key: topsecret
 ```
+
+Note the trailing '.' following most records, if not present will result in the error "Domain record is not canonical".

--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ Ensure A record
     content: 192.168.1.234
     ttl: 1440
     pdns_host: powerdns.example.com
-    pdns_port: 8081
+    pdns_port: 443
     pdns_api_key: topsecret
+    pdns_prot: https
 ```
 
 Ensure AAAA record
@@ -57,8 +58,9 @@ Ensure AAAA record
     content: 2001:cdba:0000:0000:0000:0000:3257:9652
     ttl: 1440
     pdns_host: powerdns.example.com
-    pdns_port: 8081
+    pdns_port: 8443
     pdns_api_key: topsecret
+    pdns_prot: https
 ```
 
 Ensure CNAME record
@@ -69,8 +71,9 @@ Ensure CNAME record
     type: CNAME
     content: host01.zone01.internal.example.com
     pdns_host: powerdns.example.com
-    pdns_port: 8081
+    pdns_port: 80
     pdns_api_key: topsecret
+    pdns_prot: http
 ```
 
 Note the trailing '.' following most records, if not present will result in the error "Domain record is not canonical".

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Ensure AAAA record
     pdns_prot: https
 ```
 
-Do not verify SSL certificate
-Ensure AAAA record
+Do not verify SSL certificate (this is a security risk)
+
 ```yaml
 - powerdns_record:
     name: host01.zone01.internal.example.com.

--- a/powerdns_record.py
+++ b/powerdns_record.py
@@ -58,6 +58,10 @@ options:
   pdns_api_key:
     description:
     - API Key to authenticate through PowerDNS API
+  strict_ssl_checking:
+    description:
+    - Disables strict certificate checking
+    default: false
 author: "Thomas Krahn (@nosmoht)"
 '''
 
@@ -86,12 +90,13 @@ class PowerDNSError(Exception):
 
 
 class PowerDNSClient:
-    def __init__(self, host, port, prot, api_key):
+    def __init__(self, host, port, prot, api_key, verify):
         self.url = '{prot}://{host}:{port}/api/v1'.format(prot=prot, host=host, port=port)
         self.headers = {'X-API-Key': api_key,
                         'content-type': 'application/json',
                         'accept': 'application/json'
                         }
+        self.verify = verify
 
     def _handle_request(self, req):
         if req.status_code in [200, 201, 204]:
@@ -127,7 +132,7 @@ class PowerDNSClient:
         return '{url}/{name}'.format(url=self._get_zones_url(server), name=name)
 
     def get_zone(self, server, name):
-        req = requests.get(url=self._get_zone_url(server, name), headers=self.headers)
+        req = requests.get(url=self._get_zone_url(server, name), headers=self.headers, verify=self.verify)
         if req.status_code == 422:  # zone does not exist
             return None
         return self._handle_request(req)
@@ -149,14 +154,14 @@ class PowerDNSClient:
         url = self._get_zone_url(server=server, name=zone)
         data = self._get_request_data(changetype='REPLACE', server=server, zone=zone, name=name, rtype=rtype,
                                       content=content, disabled=disabled, ttl=ttl)
-        req = requests.patch(url=url, data=json.dumps(data), headers=self.headers)
+        req = requests.patch(url=url, data=json.dumps(data), headers=self.headers, verify=self.verify)
         return self._handle_request(req)
 
     def delete_record(self, server, zone, name, rtype):
         url = self._get_zone_url(server=server, name=zone)
         data = self._get_request_data(changetype='DELETE', server=server, zone=zone, name=name, rtype=rtype)
         # module.fail_json(msg=json.dumps(data))
-        req = requests.patch(url=url, data=json.dumps(data), headers=self.headers)
+        req = requests.patch(url=url, data=json.dumps(data), headers=self.headers, verify=self.verify)
         return self._handle_request(req)
 
 
@@ -235,6 +240,7 @@ def main():
                     pdns_port=dict(type='int', default=8081),
                     pdns_prot=dict(type='str', default='http', choices=['http', 'https']),
                     pdns_api_key=dict(type='str', required=False),
+                    strict_ssl_checking=dict(type='boolean', default=True),
             ),
             supports_check_mode=True,
     )
@@ -242,7 +248,8 @@ def main():
     pdns_client = PowerDNSClient(host=module.params['pdns_host'],
                                  port=module.params['pdns_port'],
                                  prot=module.params['pdns_prot'],
-                                 api_key=module.params['pdns_api_key'])
+                                 api_key=module.params['pdns_api_key'],
+                                 verify=module.params['strict_ssl_checking'])
 
     try:
         changed, record = ensure(module, pdns_client)

--- a/powerdns_record.py
+++ b/powerdns_record.py
@@ -95,7 +95,12 @@ class PowerDNSClient:
 
     def _handle_request(self, req):
         if req.status_code in [200, 201, 204]:
-            return json.loads(req.text)
+            if req.text:
+                try:
+                    return json.loads(req.text)
+                except Exception as e:
+                    print(e) # same as yield
+            return dict()
         elif req.status_code == 404:
             error_message = 'Not found'
         else:

--- a/powerdns_record.py
+++ b/powerdns_record.py
@@ -87,7 +87,7 @@ class PowerDNSError(Exception):
 
 class PowerDNSClient:
     def __init__(self, host, port, prot, api_key):
-        self.url = '{prot}://{host}:{port}'.format(prot=prot, host=host, port=port)
+        self.url = '{prot}://{host}:{port}/api/v1'.format(prot=prot, host=host, port=port)
         self.headers = {'X-API-Key': api_key,
                         'content-type': 'application/json',
                         'accept': 'application/json'

--- a/powerdns_zone.py
+++ b/powerdns_zone.py
@@ -89,7 +89,10 @@ class PowerDNSClient:
     def _handle_request(self, req):
         if req.status_code in [200, 201, 204]:
             if req.text:
-                return json.loads(req.text)
+                try:
+                    return json.loads(req.text)
+                except Exception as e:
+                    print(e) # same as yield
             return dict()
         elif req.status_code == 404:
             error_message = 'Not found'

--- a/powerdns_zone.py
+++ b/powerdns_zone.py
@@ -80,7 +80,7 @@ class PowerDNSError(Exception):
 
 class PowerDNSClient:
     def __init__(self, host, port, prot, api_key):
-        self.url = '{prot}://{host}:{port}'.format(prot=prot, host=host, port=port)
+        self.url = '{prot}://{host}:{port}/api/v1'.format(prot=prot, host=host, port=port)
         self.headers = {'X-API-Key': api_key,
                         'content-type': 'application/json',
                         'accept': 'application/json'


### PR DESCRIPTION
This PR addresses issues https://github.com/Nosmoht/ansible-module-powerdns/issues/3, https://github.com/Nosmoht/ansible-module-powerdns/issues/4, https://github.com/Nosmoht/ansible-module-powerdns/issues/5 and https://github.com/Nosmoht/ansible-module-powerdns/issues/6 by adding the option to disable SSL certificate checking, updating the README documentation to specify the use of a trailing dot avoiding "domain record not canonical errors", fixes the API endpoint to be /api/v1 instead of / fixing common 404 errors, and adds exception handling to the JSON decoding routine avoiding the problem where the library reports a failure after a successful run.