### PR TITLE
fix bug: removed redundant api/v1

### DIFF
--- a/powerdns_record.py
+++ b/powerdns_record.py
@@ -126,7 +126,7 @@ class PowerDNSClient:
         return request_error
 
     def _get_zones_url(self, server):
-        return '{url}/api/v1/servers/{server}/zones'.format(url=self.url, server=server)
+        return '{url}/servers/{server}/zones'.format(url=self.url, server=server)
 
     def _get_zone_url(self, server, name):
         return '{url}/{name}'.format(url=self._get_zones_url(server), name=name)


### PR DESCRIPTION
Removed redundant /api/v1 from API url.
This part is already defined in https://github.com/Nosmoht/ansible-module-powerdns/blob/master/powerdns_record.py#L94