### PR TITLE
Support adding multiple records to a recordset

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,4 +92,21 @@ Ensure CNAME record
     pdns_prot: http
 ```
 
+Ensure multiple MX records
+```yaml
+- powerdns_record:
+    name: zone01.internal.example.com.
+    zone: zone01.internal.example.com
+    type: MX
+    exclusive: no
+    content: "{{ item }}"
+    pdns_host: powerdns.example.com
+    pdns_port: 80
+    pdns_api_key: topsecret
+    pdns_prot: http
+  loop:
+    - 10 mx1.zone01.internal.example.com
+    - 10 mx2.zone01.internal.example.com
+```
+
 Note the trailing '.' following most records, if not present will result in the error "Domain record is not canonical".


### PR DESCRIPTION
Allow adding an entry to an existing record given by declaring the modification as non-exclusive. This change makes it possible to create records such as A, AAAA, MX, SRV, and TXT which are configured to return more than one value in the query response.

The exclusive parameter defaults to 'yes' to preserve prior behavior of the module.

Resolves #18