### PR TITLE
Fix incorrect error message, support check_mode, new zone problem, support lua record

### DIFF
--- a/powerdns_record.py
+++ b/powerdns_record.py
@@ -39,7 +39,7 @@ options:
     description:
     - Record type
     required: false
-    choices: ['A', 'AAAA', 'CNAME', 'MX', 'PTR', 'SOA', 'SRV', 'TXT']
+    choices: ['A', 'AAAA', 'CNAME', 'MX', 'PTR', 'SOA', 'SRV', 'TXT', 'LUA']
     default: None
   set_ptr:
     description:
@@ -365,7 +365,7 @@ def main():
                     set_ptr=dict(type='bool', default=False),
                     state=dict(type='str', default='present', choices=['present', 'absent']),
                     ttl=dict(type='int', default=86400),
-                    type=dict(type='str', required=False, choices=['A', 'AAAA', 'CNAME', 'MX', 'PTR', 'SOA', 'SRV', 'TXT']),
+                    type=dict(type='str', required=False, choices=['A', 'AAAA', 'CNAME', 'MX', 'PTR', 'SOA', 'SRV', 'TXT', 'LUA']),
                     zone=dict(type='str', required=True),
                     pdns_host=dict(type='str', default='127.0.0.1'),
                     pdns_port=dict(type='int', default=8081),

--- a/powerdns_record.py
+++ b/powerdns_record.py
@@ -134,14 +134,18 @@ class PowerDNSClient:
                             message=error_message)
 
     def _get_request_error_message(self, data):
-        request_json = data.json()
-        if 'error' in request_json:
-            request_error = request_json.get('error')
-        elif 'errors' in request_json:
-            request_error = request_json.get('errors')
-        else:
-            request_error = 'No error message found'
-        return request_error
+        try:
+            request_json = data.json()
+            if 'error' in request_json:
+                request_error = request_json.get('error')
+            elif 'errors' in request_json:
+                request_error = request_json.get('errors')
+            else:
+                request_error = 'No error message found'
+            return request_error
+        except Exception:
+          pass
+        return data.text
 
     def _get_search_url(self, server):
         return '{url}/servers/{server}/search-data'.format(url=self.url,
@@ -287,8 +291,9 @@ def ensure(module, pdns_client):
         if not existing_content:
             record_content.append(content)
             try:
-                pdns_client.create_record(server=server, zone=zone_name, name=name, rtype=rtype, content=record_content,
-                                          set_ptr=set_ptr, ttl=ttl, disabled=disabled)
+                if not module.check_mode:
+                    pdns_client.create_record(server=server, zone=zone_name, name=name, rtype=rtype, content=record_content,
+                                              set_ptr=set_ptr, ttl=ttl, disabled=disabled)
                 return True, pdns_client.get_record(server=server, rtype=rtype, zone=zone_name, name=name)
             except PowerDNSError as e:
                 module.fail_json(
@@ -304,8 +309,9 @@ def ensure(module, pdns_client):
                 record_content = record_content + existing_content
 
             try:
-                pdns_client.create_record(server=server, zone=zone_name, name=name, rtype=rtype, content=record_content,
-                                          set_ptr=set_ptr, ttl=ttl, disabled=disabled)
+                if not module.check_mode:
+                    pdns_client.create_record(server=server, zone=zone_name, name=name, rtype=rtype, content=record_content,
+                                              set_ptr=set_ptr, ttl=ttl, disabled=disabled)
                 return True, pdns_client.get_record(server=server, rtype=rtype, zone=zone_name, name=name)
             except PowerDNSError as e:
                 module.fail_json(
@@ -315,7 +321,8 @@ def ensure(module, pdns_client):
         if existing_content and exclusive:
             # Delete entire record
             try:
-                pdns_client.delete_record(server=server, zone=zone_name, name=name, rtype=rtype)
+                if not module.check_mode:
+                    pdns_client.delete_record(server=server, zone=zone_name, name=name, rtype=rtype)
                 return True, None
             except PowerDNSError as e:
                 module.fail_json(
@@ -327,7 +334,8 @@ def ensure(module, pdns_client):
             record_content = existing_content
 
             try:
-                pdns_client.create_record(server=server, zone=zone_name, name=name, rtype=rtype, content=record_content,
+                if not module.check_mode:
+                    pdns_client.create_record(server=server, zone=zone_name, name=name, rtype=rtype, content=record_content,
                                           set_ptr=set_ptr, ttl=ttl, disabled=disabled)
                 return True, pdns_client.get_record(server=server, rtype=rtype, zone=zone_name, name=name)
             except PowerDNSError as e:
@@ -335,7 +343,8 @@ def ensure(module, pdns_client):
                         msg='Could not delete record {name}: HTTP {code}: {err}'.format(name=name, code=e.status_code,
                                                                                         err=e.message))
             try:
-                pdns_client.delete_record(server=server, zone=zone_name, name=name, rtype=rtype)
+                if not module.check_mode:
+                    pdns_client.delete_record(server=server, zone=zone_name, name=name, rtype=rtype)
                 return True, None
             except PowerDNSError as e:
                 module.fail_json(

--- a/powerdns_zone.py
+++ b/powerdns_zone.py
@@ -132,7 +132,7 @@ class PowerDNSClient:
 
     def get_zone(self, server, name):
         req = self.session.get(url=self._get_zone_url(server, name))
-        if req.status_code == 422:  # zone does not exist
+        if req.status_code == 422 or req.status_code == 404:  # zone does not exist
             return None
         return self._handle_request(req)
 

--- a/powerdns_zone.py
+++ b/powerdns_zone.py
@@ -111,14 +111,18 @@ class PowerDNSClient:
                             message=error_message)
 
     def _get_request_error_message(self, data):
-        request_json = data.json()
-        if 'error' in request_json:
-            request_error = request_json.get('error')
-        elif 'errors' in request_json:
-            request_error = request_json.get('errors')
-        else:
-            request_error = 'DONT KNOW'
-        return request_error
+        try:
+            request_json = data.json()
+            if 'error' in request_json:
+                request_error = request_json.get('error')
+            elif 'errors' in request_json:
+                request_error = request_json.get('errors')
+            else:
+                request_error = 'No error message found'
+            return request_error
+        except Exception:
+          pass
+        return data.text
 
     def _get_zones_url(self, server):
         return '{url}/servers/{server}/zones'.format(url=self.url, server=server)


### PR DESCRIPTION
Hi, thank you for your nice code.
I have found some problems the modules, so create pull request.

# Incorrect error message
When powerdns returns 'HTTP 500: Internal Server Error', cause JSONDecodeError exception in _get_request_error_message(), it makes message 'Error: Expecting value: line 1 column 1 (char 0)'  and lost the original error message.
For these reasons, I suggest that if _get_request_error_message fails req.json (), req.text be the error message.

## to reproduce
If I delete (eg. state: absent) 20 records consecutively, a transaction error will occur in powerdns, resulting in an HTTP 500 error. This is not a problem because it is avoided by the retry function of ansible, but I struggled because the error message was wrong. The log of powerdns is follwoing.

`Dec 21 00:43:14 [webserver] 80791907-7021-4114-89f6-0c2a391f570c HTTP ISE for "/api/v1/servers/localhost/zones/op.example.com": Exception: GSQLBackend unable to delete RRSet op.example.com|SOA: Could not execute mysql statement: delete from records where domain_id=? and name=? and type=?: Deadlock found when trying to get lock; try restarting transaction`

# Support check_mode
The powerdns_record module does not support check_mode. So fix it.

# Fix error for new zone
Some version of powerdns  returns 404 instead of 422, that cause error at get_zone() even if the module about to add new zone. So I make the get_zone() allow code 404.

# Support LUA record
Add record type 'LUA'.


