### PR TITLE
FIXED 'Could not get zone : HTTP 404: Not found' error for new zones,…

### DIFF
--- a/powerdns_zone.py
+++ b/powerdns_zone.py
@@ -128,7 +128,7 @@ class PowerDNSClient:
 
     def get_zone(self, server, name):
         req = self.session.get(url=self._get_zone_url(server, name))
-        if req.status_code == 422:  # zone does not exist
+        if req.status_code in [404, 422]:  # zone does not exist
             return None
         return self._handle_request(req)
 


### PR DESCRIPTION
FIXED 'Could not get zone : HTTP 404: Not found' error for new zones;
… seems the api changed w/ 4.2