### PR TITLE
Do not treat '0' in SOA records as changes

### DIFF
--- a/powerdns_record.py
+++ b/powerdns_record.py
@@ -39,7 +39,7 @@ options:
     description:
     - Record type
     required: false
-    choices: ['A', 'AAAA', 'CNAME', 'MX', 'PTR', 'SOA', 'SRV', 'TXT', 'LUA']
+    choices: ['A', 'AAAA', 'CNAME', 'MX', 'PTR', 'SOA', 'SRV', 'TXT', 'LUA', 'NS']
     default: None
   set_ptr:
     description:
@@ -392,7 +392,7 @@ def main():
                     set_ptr=dict(type='bool', default=False),
                     state=dict(type='str', default='present', choices=['present', 'absent']),
                     ttl=dict(type='int', default=86400),
-                    type=dict(type='str', required=False, choices=['A', 'AAAA', 'CNAME', 'MX', 'PTR', 'SOA', 'SRV', 'TXT', 'LUA']),
+                    type=dict(type='str', required=False, choices=['A', 'AAAA', 'CNAME', 'MX', 'PTR', 'SOA', 'SRV', 'TXT', 'LUA', 'NS']),
                     zone=dict(type='str', required=True),
                     pdns_host=dict(type='str', default='127.0.0.1'),
                     pdns_port=dict(type='int', default=8081),

--- a/powerdns_record.py
+++ b/powerdns_record.py
@@ -247,6 +247,33 @@ class PowerDNSClient:
         return self._handle_request(req)
 
 
+def serial(content):
+    """ Returns the serial of the given SOA record. """
+    return content.split(' ')[2]
+
+
+def ignore_serial(content):
+    """ Returns the SOA record with the serial removed. """
+
+    parts = content.split(' ')
+    return ' '.join(parts[:2] + parts[3:])
+
+
+def matches_existing_content(rtype, content, existing_content):
+    """ Returns True if the content of the given record matches the existing
+    content (i.e. if no change is necessary).
+
+    """
+
+    # Ignore the serial in SOA records if it is 0, which signifies a serial
+    # that is automatically incremented (as often happens in PowerDNS setups).
+    if rtype == 'SOA' and serial(content) == '0':
+        content = ignore_serial(content)
+        existing_content = [ignore_serial(e) for e in existing_content]
+
+    return content in existing_content
+
+
 def ensure(module, pdns_client):
     content = module.params['content']
     disabled = module.params['disabled']
@@ -300,7 +327,7 @@ def ensure(module, pdns_client):
                         msg='Could not create record {name}: HTTP {code}: {err}'.format(name=name, code=e.status_code,
                                                                                         err=e.message))
         # Check if changeable parameters match, else update record.
-        if content not in existing_content or record.get('ttl', None) != ttl or (exclusive and len(existing_content) > 1):
+        if not matches_existing_content(rtype, content, existing_content) or record.get('ttl', None) != ttl or (exclusive and len(existing_content) > 1):
             # Add provided content to record content payload
             record_content.append(content)
 


### PR DESCRIPTION
This is used to ignore the serial of the record, which is often set automatically set by PowerDNS.

With this change, we can store the SOA record thusly:
```
powerdns_record:
    name: 'example.org.'
    zone: 'example.org.'
    content: 'hostmaster.example.org. 0 43200 3600 2419200 86400
    type: 'A'
    ...
```

And even though the SOA returned by the DNS server would include a serial like '2020092801', Ansible would not report a change, unless we change any of the other values.

Technically all '0' in the SOA record are ignored, but I figure the only field you'd ever set to zero would be the serial. And even then, if that's what you want, it will be set to that initially. However, should the serial update independently, it wouldn't catch that change.

Anyway, not sure if this is useful to you - it might be a bit of a special case - but I thought I'd try to upstream this anyway. If nothing else than to start a discussion on how to square the rather static SOA record defined in Ansible with the dynamic SOA record returned by PowerDNS.

And of course, thanks for your work!