### PR TITLE
add support for http basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,4 +142,21 @@ Ensure multiple MX records
     - 10 mx2.zone01.internal.example.com
 ```
 
+Use HTTP Basic Auth instead of API Key
+```yaml
+- powerdns_record:
+    name: database.zone01.internal.example.com.
+    zone: zone01.internal.example.com
+    type: CNAME
+    content: host01.zone01.internal.example.com
+    pdns_host: powerdns.example.com
+    pdns_port: 80
+    pdns_api_username: myuser
+    pdns_api_password: mytopsecretpassword
+    pdns_prot: http
+```
+
+`pdns_api_key` takes preference if both `pdns_api_key` and `pdns_api_username`/`pdns_api_password` are supplied.
+
+
 Note the trailing '.' following most records, if not present will result in the error "Domain record is not canonical".

--- a/powerdns_record.py
+++ b/powerdns_record.py
@@ -74,6 +74,12 @@ options:
   pdns_api_key:
     description:
     - API Key to authenticate through PowerDNS API
+  pdns_api_username:
+    description:
+    - API Username to authenticate through PowerDNS API with basic auth
+  pdns_api_password:
+    description:
+    - API Password to authenticate through PowerDNS API with basic auth
   strict_ssl_checking:
     description:
     - Disables strict certificate checking
@@ -96,6 +102,7 @@ EXAMPLES = '''
 
 try:
     import requests
+    from requests.auth import HTTPBasicAuth
     HAS_REQUESTS = True
 except ImportError:
     HAS_REQUESTS = False
@@ -110,10 +117,13 @@ class PowerDNSError(Exception):
 
 
 class PowerDNSClient:
-    def __init__(self, host, port, prot, api_key, verify):
+    def __init__(self, host, port, prot, api_key, api_username, api_password, verify):
         self.url = '{prot}://{host}:{port}/api/v1'.format(prot=prot, host=host, port=port)
         self.session = requests.Session()
-        self.session.headers.update({'X-API-Key': api_key})
+        if api_key:
+            self.session.headers.update({'X-API-Key': api_key})
+        elif (api_username and api_password):
+            self.session.auth = HTTPBasicAuth(api_username, api_password)
         self.session.verify = verify
 
     def _handle_request(self, req):
@@ -398,6 +408,8 @@ def main():
                     pdns_port=dict(type='int', default=8081),
                     pdns_prot=dict(type='str', default='http', choices=['http', 'https']),
                     pdns_api_key=dict(type='str', required=False),
+                    pdns_api_username=dict(type='str', required=False),
+                    pdns_api_password=dict(type='str', required=False),
                     strict_ssl_checking=dict(type='bool', default=True),
             ),
             supports_check_mode=True,
@@ -410,6 +422,8 @@ def main():
                                  port=module.params['pdns_port'],
                                  prot=module.params['pdns_prot'],
                                  api_key=module.params['pdns_api_key'],
+                                 api_username=module.params['pdns_api_username'],
+                                 api_password=module.params['pdns_api_password'],
                                  verify=module.params['strict_ssl_checking'])
 
     try:


### PR DESCRIPTION
Adds support for basic auth, to support use cases such as when powerdns is behind a proxy to add ldap support, etc.

I need it in my case, and may also be useful to others.