### PR TITLE
Add list support for record content

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,15 +136,13 @@ Ensure multiple MX records
     name: zone01.internal.example.com.
     zone: zone01.internal.example.com
     type: MX
-    exclusive: no
-    content: "{{ item }}"
+    content:
+      - 10 mx1.zone01.internal.example.com
+      - 10 mx2.zone01.internal.example.com
     pdns_host: powerdns.example.com
     pdns_port: 80
     pdns_api_key: topsecret
     pdns_prot: http
-  loop:
-    - 10 mx1.zone01.internal.example.com
-    - 10 mx2.zone01.internal.example.com
 ```
 
 Use HTTP Basic Auth instead of API Key


### PR DESCRIPTION
This PR implements the ability to specify lists as the content to create or delete records.

In the content parameter you can now use a list to specify multiple records for the same type. If `exclusive: true` is set records are explicitly updated as specified. If set to `false` existing and specified lists are being compared, merged and records are being adjusted accordingly.

If a string instead of a list has been specified as content it's automatically being converted into a list item. Making the code fully backwards compatible.

Documentation of MX records has been updated to reflect the new way to ensure multiple records of the same type are being created properly.

Solves #32